### PR TITLE
[BE-1925] Customer names should be normalized before applied to Q2 and Spiral DB

### DIFF
--- a/src/main/java/net/binis/codegen/validation/annotation/SanitizeLowerCase.java
+++ b/src/main/java/net/binis/codegen/validation/annotation/SanitizeLowerCase.java
@@ -25,6 +25,7 @@ import net.binis.codegen.annotation.validation.AliasFor;
 import net.binis.codegen.annotation.validation.AsCode;
 import net.binis.codegen.annotation.validation.Sanitize;
 import net.binis.codegen.validation.sanitizer.LambdaSanitizer;
+import net.binis.codegen.validation.sanitizer.NullAwareLambdaSanitizer;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -34,7 +35,7 @@ import java.lang.annotation.Target;
 @CodeAnnotation
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Sanitize(LambdaSanitizer.class)
+@Sanitize(NullAwareLambdaSanitizer.class)
 public @interface SanitizeLowerCase {
     @AsCode
     @AliasFor("params")

--- a/src/main/java/net/binis/codegen/validation/annotation/SanitizeUpperCase.java
+++ b/src/main/java/net/binis/codegen/validation/annotation/SanitizeUpperCase.java
@@ -25,6 +25,7 @@ import net.binis.codegen.annotation.validation.AliasFor;
 import net.binis.codegen.annotation.validation.AsCode;
 import net.binis.codegen.annotation.validation.Sanitize;
 import net.binis.codegen.validation.sanitizer.LambdaSanitizer;
+import net.binis.codegen.validation.sanitizer.NullAwareLambdaSanitizer;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -34,7 +35,7 @@ import java.lang.annotation.Target;
 @CodeAnnotation
 @Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-@Sanitize(LambdaSanitizer.class)
+@Sanitize(NullAwareLambdaSanitizer.class)
 public @interface SanitizeUpperCase {
     @AsCode
     @AliasFor("params")

--- a/src/main/java/net/binis/codegen/validation/sanitizer/LambdaSanitizer.java
+++ b/src/main/java/net/binis/codegen/validation/sanitizer/LambdaSanitizer.java
@@ -26,8 +26,6 @@ import net.binis.codegen.validation.Sanitizer;
 
 import java.util.function.Function;
 
-import static java.util.Objects.nonNull;
-
 @AsCode("((java.util.function.Function<{type}, {type}>) %s)")
 public class LambdaSanitizer implements Sanitizer {
 
@@ -39,7 +37,7 @@ public class LambdaSanitizer implements Sanitizer {
 
     @Override
     public <T> T sanitize(T value, Object... params) {
-        if (nonNull(value) && params.length > 0 && params[0] instanceof Function) {
+        if (params.length > 0 && params[0] instanceof Function) {
             return (T) ((Function) params[0]).apply(value);
         }
         return value;

--- a/src/main/java/net/binis/codegen/validation/sanitizer/LambdaSanitizer.java
+++ b/src/main/java/net/binis/codegen/validation/sanitizer/LambdaSanitizer.java
@@ -26,6 +26,8 @@ import net.binis.codegen.validation.Sanitizer;
 
 import java.util.function.Function;
 
+import static java.util.Objects.nonNull;
+
 @AsCode("((java.util.function.Function<{type}, {type}>) %s)")
 public class LambdaSanitizer implements Sanitizer {
 
@@ -37,7 +39,7 @@ public class LambdaSanitizer implements Sanitizer {
 
     @Override
     public <T> T sanitize(T value, Object... params) {
-        if (params.length > 0 && params[0] instanceof Function) {
+        if (nonNull(value) && params.length > 0 && params[0] instanceof Function) {
             return (T) ((Function) params[0]).apply(value);
         }
         return value;

--- a/src/main/java/net/binis/codegen/validation/sanitizer/NullAwareLambdaSanitizer.java
+++ b/src/main/java/net/binis/codegen/validation/sanitizer/NullAwareLambdaSanitizer.java
@@ -1,0 +1,17 @@
+package net.binis.codegen.validation.sanitizer;
+
+import java.util.function.Function;
+
+import static java.util.Objects.nonNull;
+
+public class NullAwareLambdaSanitizer extends LambdaSanitizer {
+
+    @Override
+    public <T> T sanitize(T value, Object... params) {
+        if (nonNull(value)) {
+            return super.sanitize(value, params);
+        }
+        return value;
+    }
+
+}


### PR DESCRIPTION
* Allow LambdaSanitizer to support NULL values without throwing a NPE